### PR TITLE
Rework file monitoring

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,39 +60,75 @@ class Application( Tk ):
         """"Force a pass in the background worker to enter the GUI pass"""
         self.bg_worker_force_gui = True
 
+    #
+    # perhaps 'has_files' and 'file_count_changed' should be moved to modules/app/read_write.py?
+    #
+    def has_files( self ) -> bool:
+        """Check if files in 'txt' or 'pdf' exist.
+        'hasTextFiles()' and 'hasPdfFiles()' updates the current file count as well."""
+        try:
+            has_text_files = self.read_write.hasTextFiles()
+            has_pdf_files = self.read_write.hasPdfFiles()
+            
+            return has_text_files or has_pdf_files
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            return False
+
+    def file_count_changed( self ) -> bool:
+        """Deteriminte wheter the file count has changed since previous iteration."""
+        if self.read_write.numShareableFiles != self.read_write.prevShareableFiles:
+            print( f"Files have changed? num txt files: {self.read_write.numShareableFiles}" )
+            return True
+
+        if self.read_write.numPDFFiles != self.read_write.prevPDFFiles:
+            print( f"Files have changed? num pdf files: {self.read_write.numPDFFiles}" )
+            return True
+
+        return False
+
+    def update_previous_file_count( self ) -> None:
+        """This method sets the file count to the current count. 
+        This is useful for tracking changes in file counts across operations."""
+        self.read_write.prevShareableFiles = self.read_write.numShareableFiles
+        self.read_write.prevPDFFiles = self.read_write.numPDFFiles
+
     def bg_worker_do( self ) -> None:
+        """Background worker that continuously monitors and updates the application state.
+
+        This method performs the following actions in an infinite loop:
+        - Checks for changes in the file count and takes following actions:
+            - If there are changes and files exist while not on the creation page, it reloads the current frame.
+            - If there are no files or on the creation page, it navigates back to the home frame.
+        - Updates the recorded file count for the next iteration comparisons.
+        - Periodically refreshes device data every 10 ticks when in the share files frame.
+        - If a forced device update is triggered, it updates devices immediately.
+    
+        The loop sleeps for one second between iterations to manage the frequency.
+        """
         while True:
             print( self.bg_worker_tick )
 
-            #
-            # scan 'files' folder to track changes
-            #
-            if self.read_write.hasTextFiles() and self.read_write.numShareableFiles != self.read_write.prevShareableFiles:
-                """Files found - Files have changed"""
-                
-                print( f"Files have changed? num files: {self.read_write.numShareableFiles}" )
+            # Monitor changes in the file count by comparing the current count with the previous iteration.
+            # If files exist and the current page handles file reading, reload the current frame.
+            # If the file count is zero or the application is on the creation page, call goHome().
+            # The goHome() function will determine whether to display the create_files frame or the share_files frame.
+            has_files = self.has_files()
+            num_changed = self.file_count_changed()
 
-                # reload the current frame/page
-                if self.tk_root.current_frame > self.tk_root.FRAME_CREATE_FILES:
+            if num_changed:
+                if has_files and self.tk_root.current_frame > self.tk_root.FRAME_CREATE_FILES:
+                    # reload the current frame/page
                     reload_frame : bool = True # redundant bool ..
-                    self.tk_root.after(10, self.tk_root.show_frame( self.tk_root.current_frame, reload_frame ) )
+                    self.tk_root.after( 10, self.tk_root.show_frame( self.tk_root.current_frame, reload_frame ) )
                 
-                # go home if previously ther were no files    
                 else:
-                    self.tk_root.after(10, self.tk_root.goHome() )
+                    self.tk_root.after( 10, self.tk_root.goHome() )
+                
+                self.update_previous_file_count()
 
-                self.read_write.prevShareableFiles = self.read_write.numShareableFiles
-            
-            elif self.read_write.numShareableFiles != self.read_write.prevShareableFiles:
-                """NO files found - Files have been removed?"""
-                print("Files have been removed?")
-
-                self.tk_root.after(10, self.tk_root.goHome() )
-                self.read_write.prevShareableFiles = self.read_write.numShareableFiles
-
-            #
-            # A GUI update pass, force or every x secconds
-            #
+            # Update the device list every X seconds when the share_files frame is open.
+            # If self.bg_worker_force_gui is True, trigger an earlier update.
             if self.bg_worker_tick % 10 == 0 or self.bg_worker_force_gui:
                 if self.tk_root.is_frame_active( self.tk_root.FRAME_SHARE_FILES ):
                     self.tk_root.after(10, self.tk_root.frames[ self.tk_root.FRAME_SHARE_FILES ].updateDevices() )

--- a/modules/app/gui.py
+++ b/modules/app/gui.py
@@ -78,12 +78,13 @@ class Gui( tk.Tk ):
         frame.tkraise()
         self.current_frame = index
 
-    def decide_main_frame( self ) -> int:
-        """Decide wheter to show 'create' or 'share' files GUI page
-        - Need to revisit this method once more frames/pages are added"""
+    def get_frame_index_for_file_sharing( self ) -> int:
+        """Return the index of 'create_files' or 'share_files' frame/page
+        based on the presence of files"""
 
         index : int = 0
-        if self.context.read_write.hasTextFiles():
+
+        if self.context.has_files():
             index = self.FRAME_SHARE_FILES
         else:
             index = self.FRAME_CREATE_FILES
@@ -91,6 +92,7 @@ class Gui( tk.Tk ):
         return index
 
     def goHome( self ):
+        """Determine whether to display the 'create_files' or 'share_files' frame/page."""
         reload_frame : bool = True # redundant bool ..
-        self.show_frame( self.decide_main_frame(), reload_frame )
+        self.show_frame( self.get_frame_index_for_file_sharing(), reload_frame )
         return

--- a/modules/app/read_write.py
+++ b/modules/app/read_write.py
@@ -11,6 +11,9 @@ class ReadWrite:
         self.numShareableFiles: int = 0
         self.prevShareableFiles: int = 0
 
+        self.numPDFFiles: int = 0
+        self.prevPDFFiles: int = 0
+
         self.dir = Path(self.settings.filesdir).resolve()
         self.textDir = self.dir.joinpath(self.settings.txt_subdir)
         self.pdfDir = self.dir.joinpath(self.settings.pdf_subdir)
@@ -51,7 +54,9 @@ class ReadWrite:
 
     def hasPdfFiles(self) -> bool:
         """Check if there are any text files."""
-        return bool(self.getFiles(self.pdfDir, True))
+        files = self.getFiles(self.pdfDir, True)
+        self.numPDFFiles = len(files)
+        return bool(files)
 
     def getPdfFiles(self) -> list:
         """Get all text files."""

--- a/modules/gui/share_files.py
+++ b/modules/gui/share_files.py
@@ -144,6 +144,11 @@ class GUI_ShareFiles( GuiModule ):
         
         self.current_position.y += 25
 
+    def _debugClearFiles( self ) -> None:
+        """Debug function to clear all files 'txt' and 'pdf'"""
+        self.context.read_write.removeTextFiles()
+        self.context.read_write.removePdfFiles()
+
     def onStart( self ):
         lan_info = Label( self, text=f"LAN Address: {self.settings.server_ip}:{self.settings.tcp_port}" )
         lan_info.configure(font=("Helvetica", 14, "bold"))
@@ -184,7 +189,7 @@ class GUI_ShareFiles( GuiModule ):
         self.context.bg_worker_force_gui_update()
 
         button = Button( self, text = "Opnieuw Beginnen", 
-               command = lambda : self.context.read_write.removeTextFiles() )
+               command = lambda : self._debugClearFiles() )
         button.place( x = self.settings.appplication_width - 130, 
                       y = self.settings.appplication_height - 40 )
 


### PR DESCRIPTION
In this pull request, the background worker that does file monitoring has been slighly reworked.

**Background worker:**
- Variables are added to keep track of the pdf file count here: '[modules/app/read_write.py](https://github.com/mhoek2/tcp-share/blob/rework-file-monitoring/modules/app/read_write.py#L14-L15)'
- Extracted snippets from the background worker to a new [has_files()](https://github.com/mhoek2/tcp-share/blob/rework-file-monitoring/main.py#L66-L76) function, so it can be used in '[modules/app/gui.py](https://github.com/mhoek2/tcp-share/blob/rework-file-monitoring/modules/app/gui.py#L87)' as well.
- Extracted [file_count_changed()](https://github.com/mhoek2/tcp-share/blob/rework-file-monitoring/main.py#L78-L88) function that checks if the 'txt' or 'pdf' file count have changed since the last tick.

This makes the actual [method ](https://github.com/mhoek2/tcp-share/blob/rework-file-monitoring/main.py#L119-L128) that either reloads or navigates to another frame more clear and concice.

**Minor changes:**
 - Added function definition comments 
 - Extended the "Opnieuw Beginnen" to clear both text and pdf folders.


